### PR TITLE
The git file that needs updating is in root's home directory.

### DIFF
--- a/docs/development/git.rst
+++ b/docs/development/git.rst
@@ -7,15 +7,16 @@ Recommended Git Flow and configuration
   so you can track any changes made to the development documentation, as
   well as improvements to the appliance.
 
-* And finally, tell git who you are by editing ``/etc/.bashrc.d/git``::
+* And finally, tell git who you are by editing ``~/.bashrc.d/git``::
 
     export GIT_AUTHOR_NAME="Your Name"
     export GIT_AUTHOR_EMAIL="your@email.com"
     export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME
     export GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
 
-    # source that file as changes will only take effect at login
-    . /etc/.bashrc.d/git 
+* Source that file as changes will only take effect at login
+
+    . ~/.bashrc.d/git 
 
 
 .. _Git Flow and guidelines: https://github.com/turnkeylinux/tracker/blob/master/GITFLOW.rst


### PR DESCRIPTION
The original doc referred to /etc/.bashrc.d/git, which does not exist. I believe the intention was to refer to the file in root's home directory.
