### PR TITLE
Added note about firewall on TKL Hub

### DIFF
--- a/docs/development/maintenance.rst
+++ b/docs/development/maintenance.rst
@@ -95,6 +95,9 @@ Once the ``CHROOT_ONLY`` build is successful, lets test it::
     /etc/init.d/mysql stop
     exit
 
+Note: If testing via the Hub you will need to adjust the Firewall rules 
+to open any relevant ports (e.g. 80 for http, etc).
+
 Testing complete? Let's perform a cleanup::
 
     deck -D build/root.tmp


### PR DESCRIPTION
Just added a brief note about firewall adjustments when testing via the Hub. 

Although to many (most?) this would be obvious, it tripped me up recently and i wasted a fair bit of time trying to work out why Apache wasn't working at all...

There may be other places where it could be mentioned but following a quick look this seemed like the most logical place to put it (although perhaps it should go in tkldev / docs / installation.rst where the Hub is mentioned there?)
