### PR TITLE
15.0 Overlayfs update

### DIFF
--- a/overlay/etc/modules-load.d/overlayfs.conf
+++ b/overlay/etc/modules-load.d/overlayfs.conf
@@ -1,0 +1,1 @@
+overlay

--- a/overlay/etc/useraufs.conf
+++ b/overlay/etc/useraufs.conf
@@ -1,2 +1,0 @@
-allow_user root
-allow_dir /turnkey/fab

--- a/overlay/usr/local/sbin/tkldev-setup
+++ b/overlay/usr/local/sbin/tkldev-setup
@@ -15,11 +15,11 @@ if [ ! -d $BOOTSTRAP_PATH ]; then
     mkdir -p $(dirname $BOOTSTRAP_PATH)
     cd $(dirname $BOOTSTRAP_PATH)
     wget -nc $IMAGES/bootstrap/$BOOTSTRAP_NAME.tar.gz
-    wget -nc $IMAGES/bootstrap/$BOOTSTRAP_NAME.tar.gz.sig
+    wget -nc $IMAGES/bootstrap/$BOOTSTRAP_NAME.tar.gz.hash
 
     info "verifying $BOOTSTRAP_NAME"
     gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 0x$GPGKEY
-    gpg --verify $BOOTSTRAP_NAME.tar.gz.sig
+    gpg --verify $BOOTSTRAP_NAME.tar.gz.hash
 
     info "unpacking $BOOTSTRAP_NAME"
     mkdir $BOOTSTRAP_PATH

--- a/plan/main
+++ b/plan/main
@@ -21,3 +21,5 @@ sysv-rc-conf
 
 syslinux
 syslinux-utils
+
+dirmngr

--- a/plan/main
+++ b/plan/main
@@ -9,7 +9,6 @@ pool
 chanko
 autoversion
 repo
-useraufs
 verseek
 
 make


### PR DESCRIPTION
- Replaced aufs/useraufs with overlayfs
- Updated tkldev-setup to work with .hash files instead of .sig files (closes https://github.com/turnkeylinux/tracker/issues/947)