### PR TITLE
Include debootstrap in plan - supports building of bootstrap and closes #1450.

### DIFF
--- a/plan/main
+++ b/plan/main
@@ -16,3 +16,5 @@ syslinux
 syslinux-utils
 
 dirmngr
+
+debootstrap             /* required for building bootstrap */


### PR DESCRIPTION
Include `debootstrap` in TKLDev plan.

Closes https://github.com/turnkeylinux/tracker/issues/1450

Also associated with a minor bootstrap tweak: https://github.com/turnkeylinux/bootstrap/pull/4