### PR TITLE
Rebuild for v18.1

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,23 @@
+turnkey-tkldev-18.1 (1) turnkey; urgency=low
+
+  * Rebuild for v18.1 - including more recent v18.0 common bugfixes & latest
+    Debian packages.
+
+  * Confconsole: bugfix broken DNS-01 Let's Encrypt challenge- closes #1876 &
+    #1895.
+    [Jeremy Davis <jeremy@turnkeylinux.org>]
+
+  * Ensure hashfile includes URL to public key - closes #1864.
+
+  * Include webmin-logviewer module by default - closes #1866.
+
+  * Web management console (webmin):
+    - Upgraded webmin to v2.105.
+    - Replace webmin-shell with webmin-xterm module by default - closes #1904.
+    - Disabled Webmin Let's Encrypt (for now).
+
+ -- Jeremy Davis <jeremy@turnkeylinux.org>  Thu, 20 Jun 2024 03:21:43 +0000
+
 turnkey-tkldev-18.0 (1) turnkey; urgency=low
 
   * Upgraded base distribution to Debian 12.x/Bookworm.

--- a/changelog
+++ b/changelog
@@ -3,7 +3,10 @@ turnkey-tkldev-18.1 (1) turnkey; urgency=low
   * Rebuild for v18.1 - including more recent v18.0 common bugfixes & latest
     Debian packages.
 
-  * Confconsole: bugfix broken DNS-01 Let's Encrypt challenge- closes #1876 &
+  * Clone "core" buildcode on firstboot - reintroduce previous default
+    behaviour - closes #1857.
+
+  * Confconsole: bugfix broken DNS-01 Let's Encrypt challenge - closes #1876 &
     #1895.
     [Jeremy Davis <jeremy@turnkeylinux.org>]
 

--- a/overlay/usr/lib/inithooks/firstboot.d/40tkldev
+++ b/overlay/usr/lib/inithooks/firstboot.d/40tkldev
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-/usr/local/sbin/tkldev-setup
+/usr/local/sbin/tkldev-setup core


### PR DESCRIPTION
(was: Clone core on firstboot (reimplement previous default behaviour)

Rebuild for v18.1

Minor tweak for TKLDev firstboot (re-implement previous default behaviour of cloning Core).

Closes https://github.com/turnkeylinux/tracker/issues/1857