### PR TITLE
set squid shutdown_lifetime to 0

### DIFF
--- a/overlay/etc/squid/squid.conf
+++ b/overlay/etc/squid/squid.conf
@@ -32,3 +32,5 @@ refresh_pattern .		0	20%	4320
 
 maximum_object_size 1024 MB
 cache_dir ufs /var/spool/squid 2048 16 256
+
+shutdown_lifetime 0


### PR DESCRIPTION
This makes Squid shut down immediately instead of always waiting 30s by
default. It makes the first TKLDev boot faster by 30s because inithooks
are restarting Squid and avoids systemd getting stuck during system
shutdown waiting for Squid to exit.

See: https://squid-users.squid-cache.narkive.com/nmApQoqN/question-about-shutdown-lifetime-behavior
