### PR TITLE
Update squid openssl conf to generate a CA cert that works on Trixie

### DIFF
--- a/changelog
+++ b/changelog
@@ -2,6 +2,9 @@ turnkey-tkldev-19.0 (1) turnkey; urgency=low
 
   * Upgraded base distribution to Debian 13.x/Trixie.
 
+  * Update squid https proxy CA cert config so it generates a CA cert that is
+    valid against current requirements.
+
   * TurnKey build tool (fab):
 
     - Bugfix:
@@ -137,7 +140,8 @@ turnkey-tkldev-19.0 (1) turnkey; urgency=low
       notes for full details.
 
   * Misc code cleanup and improvements.
- -- Jeremy Davis <jeremy@turnkeylinux.org>  Thu, 18 Jun 2026 16:21:24 +1000
+
+ -- Jeremy Davis <jeremy@turnkeylinux.org>  Thu, 25 Jun 2026 12:42:24 +1000
 
 turnkey-tkldev-18.1 (1) turnkey; urgency=low
 

--- a/overlay/etc/squid/tkl-openssl.cnf
+++ b/overlay/etc/squid/tkl-openssl.cnf
@@ -1,12 +1,18 @@
 #
 # CA SSL template for TKLDev squid proxy
 #
-
 [ req ]
 default_bits            = 2048
 distinguished_name      = req_distinguished_name
 prompt                  = no
 policy                  = policy_anything
+x509_extensions         = v3_ca
 
 [ req_distinguished_name ]
 commonName              = @HostName@
+
+[ v3_ca ]
+basicConstraints        = critical, CA:TRUE
+keyUsage                = critical, keyCertSign, cRLSign
+subjectKeyIdentifier    = hash
+authorityKeyIdentifier  = keyid:always, issuer


### PR DESCRIPTION
It looks like our squid proxy https CA cert (which worked fine in Bookworm) isn't valid in Trixie. My reading suggests that the previous cert we were generating wasn't actually a proper valid CA cert. My testing suggests that this does the trick.

FWIW to fix a broken cert on an existing TKLDev server, clone this repo locally and cd in. Then:
```
cp overlay/etc/squid/tkl-openssl.cnf /etc/squid/tkl-openssl.cnf
./overlay/usr/lib/inithooks/firstboot.d/20regen-proxy-cert
```
And you should be good.

Re-running `make` on a broken build should fix it, but you may need to do a full `make clean && make`.

@OnGle - I strongly suspect that this is the root cause of the issue with curl that we discussed a while ago offline.